### PR TITLE
fix: 微信浏览器字体适配rem

### DIFF
--- a/mobx/src/index.html
+++ b/mobx/src/index.html
@@ -10,7 +10,46 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" >
   <title></title>
   <script>
-    !function(x){function w(){var v,u,t,tes,s=x.document,r=s.documentElement,a=r.getBoundingClientRect().width;if(!v&&!u){var n=!!x.navigator.appVersion.match(/AppleWebKit.*Mobile.*/);v=x.devicePixelRatio;tes=x.devicePixelRatio;v=n?v:1,u=1/v}if(a>=640){r.style.fontSize="40px"}else{if(a<=320){r.style.fontSize="20px"}else{r.style.fontSize=a/320*20+"px"}}}x.addEventListener("resize",function(){w()});w()}(window);
+    !(function(x) {
+        function w() {
+          var v,
+            u,
+            t,
+            tes,
+            s = x.document,
+            r = s.documentElement,
+            a = r.getBoundingClientRect().width;
+          if (!v && !u) {
+            var n = !!x.navigator.appVersion.match(/AppleWebKit.*Mobile.*/);
+            v = x.devicePixelRatio;
+            tes = x.devicePixelRatio;
+            (v = n ? v : 1), (u = 1 / v);
+          }
+
+          // 微信字体大小适配处理
+          var divEle = document.createElement('div');
+          divEle.style = 'font-size: 20px';
+          document.body.appendChild(divEle);
+
+          var scaledFontSize = parseFloat(window.getComputedStyle(divEle, null).getPropertyValue('font-size'));
+          document.body.appendChild(divEle);
+          var scaleFactor = 20 / scaledFontSize;
+
+          if (a >= 640) {
+            r.style.fontSize = scaleFactor * 40 + 'px';
+          } else {
+            if (a <= 320) {
+              r.style.fontSize = scaleFactor * 20 + 'px';
+            } else {
+              r.style.fontSize = scaleFactor * (a / 320) * 20 + 'px';
+            }
+          }
+        }
+        x.addEventListener('resize', function() {
+          w();
+        });
+        w();
+      })(window);
   </script>
 </head>
 <body>

--- a/redux/src/index.html
+++ b/redux/src/index.html
@@ -10,7 +10,46 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" >
   <title></title>
   <script>
-    !function(x){function w(){var v,u,t,tes,s=x.document,r=s.documentElement,a=r.getBoundingClientRect().width;if(!v&&!u){var n=!!x.navigator.appVersion.match(/AppleWebKit.*Mobile.*/);v=x.devicePixelRatio;tes=x.devicePixelRatio;v=n?v:1,u=1/v}if(a>=640){r.style.fontSize="40px"}else{if(a<=320){r.style.fontSize="20px"}else{r.style.fontSize=a/320*20+"px"}}}x.addEventListener("resize",function(){w()});w()}(window);
+    !(function(x) {
+        function w() {
+          var v,
+            u,
+            t,
+            tes,
+            s = x.document,
+            r = s.documentElement,
+            a = r.getBoundingClientRect().width;
+          if (!v && !u) {
+            var n = !!x.navigator.appVersion.match(/AppleWebKit.*Mobile.*/);
+            v = x.devicePixelRatio;
+            tes = x.devicePixelRatio;
+            (v = n ? v : 1), (u = 1 / v);
+          }
+
+          // 微信字体大小适配处理
+          var divEle = document.createElement('div');
+          divEle.style = 'font-size: 20px';
+          document.body.appendChild(divEle);
+
+          var scaledFontSize = parseFloat(window.getComputedStyle(divEle, null).getPropertyValue('font-size'));
+          document.body.appendChild(divEle);
+          var scaleFactor = 20 / scaledFontSize;
+
+          if (a >= 640) {
+            r.style.fontSize = scaleFactor * 40 + 'px';
+          } else {
+            if (a <= 320) {
+              r.style.fontSize = scaleFactor * 20 + 'px';
+            } else {
+              r.style.fontSize = scaleFactor * (a / 320) * 20 + 'px';
+            }
+          }
+        }
+        x.addEventListener('resize', function() {
+          w();
+        });
+        w();
+      })(window);
   </script>
 </head>
 <body>

--- a/wxcloud/client/src/index.html
+++ b/wxcloud/client/src/index.html
@@ -10,7 +10,46 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" >
   <title></title>
   <script>
-    !function(x){function w(){var v,u,t,tes,s=x.document,r=s.documentElement,a=r.getBoundingClientRect().width;if(!v&&!u){var n=!!x.navigator.appVersion.match(/AppleWebKit.*Mobile.*/);v=x.devicePixelRatio;tes=x.devicePixelRatio;v=n?v:1,u=1/v}if(a>=640){r.style.fontSize="40px"}else{if(a<=320){r.style.fontSize="20px"}else{r.style.fontSize=a/320*20+"px"}}}x.addEventListener("resize",function(){w()});w()}(window);
+    !(function(x) {
+        function w() {
+          var v,
+            u,
+            t,
+            tes,
+            s = x.document,
+            r = s.documentElement,
+            a = r.getBoundingClientRect().width;
+          if (!v && !u) {
+            var n = !!x.navigator.appVersion.match(/AppleWebKit.*Mobile.*/);
+            v = x.devicePixelRatio;
+            tes = x.devicePixelRatio;
+            (v = n ? v : 1), (u = 1 / v);
+          }
+
+          // 微信字体大小适配处理
+          var divEle = document.createElement('div');
+          divEle.style = 'font-size: 20px';
+          document.body.appendChild(divEle);
+
+          var scaledFontSize = parseFloat(window.getComputedStyle(divEle, null).getPropertyValue('font-size'));
+          document.body.appendChild(divEle);
+          var scaleFactor = 20 / scaledFontSize;
+
+          if (a >= 640) {
+            r.style.fontSize = scaleFactor * 40 + 'px';
+          } else {
+            if (a <= 320) {
+              r.style.fontSize = scaleFactor * 20 + 'px';
+            } else {
+              r.style.fontSize = scaleFactor * (a / 320) * 20 + 'px';
+            }
+          }
+        }
+        x.addEventListener('resize', function() {
+          w();
+        });
+        w();
+      })(window);
   </script>
 </head>
 <body>


### PR DESCRIPTION
> 微信安卓版 7.0.10 版本起，网页的字体会跟随微信设置里的字体大小更改而变化。

这个会导致rem布局错乱，详细见[关于微信安卓端网页字体适配的通知](https://developers.weixin.qq.com/community/develop/doc/000a26b86948f8743cb9a6da951409?highLine=%25E5%25AD%2597%25E4%25BD%2593)，[]()