### PR TITLE
fix: 2.x版本状态管理模板缺少@tarojs/taro-rn包

### DIFF
--- a/mobx/pkg
+++ b/mobx/pkg
@@ -40,6 +40,7 @@
     "@tarojs/taro-swan": "<%= version %>",
     "@tarojs/taro-tt": "<%= version %>",
     "@tarojs/taro-weapp": "<%= version %>",
+    "@tarojs/taro-rn": "<%= version %>",
     "@tarojs/mobx": "<%= version %>",
     "@tarojs/mobx-h5": "<%= version %>",
     "mobx": "4.8.0",

--- a/mobx/pkg
+++ b/mobx/pkg
@@ -43,6 +43,7 @@
     "@tarojs/taro-rn": "<%= version %>",
     "@tarojs/mobx": "<%= version %>",
     "@tarojs/mobx-h5": "<%= version %>",
+    "@tarojs/mobx-rn": "<%= version %>",
     "mobx": "4.8.0",
     "babel-runtime": "^6.26.0",
     "nervjs": "^1.5.5",

--- a/redux/pkg
+++ b/redux/pkg
@@ -42,6 +42,7 @@
     "@tarojs/taro-swan": "<%= version %>",
     "@tarojs/taro-tt": "<%= version %>",
     "@tarojs/taro-weapp": "<%= version %>",
+    "@tarojs/taro-rn": "<%= version %>",
     "babel-runtime": "^6.26.0",
     "nervjs": "^1.5.5",
     "nerv-devtools": "^1.5.5",


### PR DESCRIPTION
2.x版本创建项目选择`redux`模板，缺少`@tarojs/taro-rn`包
![缺少@tarojs/taro-rn包](https://user-images.githubusercontent.com/8678079/83023208-2e755480-a05f-11ea-91bd-5d7c59476d0d.png)
