### PR TITLE
fix: 引入 app.css 避免 common.wxss 无法引入的 bug

### DIFF
--- a/vuex/src/app.js
+++ b/vuex/src/app.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import store from './store'
-
+import 'app.css'
 // Vue.config.productionTip = false
 
 const App = new Vue({


### PR DESCRIPTION
## 这个pr做什么
避免模版没有引入 app.css 引起的这个 bug。issue[Vue多页面多组件时样式未引入]( https://github.com/NervJS/taro/issues/7277 )