### PR TITLE
add module exports to js eslint config

### DIFF
--- a/wxcloud/client/.eslintrc.js
+++ b/wxcloud/client/.eslintrc.js
@@ -1,4 +1,8 @@
-{
+<%if (framework === 'vue') {-%>
+// ESLint 检查 .vue 文件需要单独配置编辑器：
+// https://eslint.vuejs.org/user-guide/#editor-integrations
+<%}-%>
+module.exports = {
 <%if (!locals.typescript) {-%>
   "extends": ["taro"],
   "rules": {
@@ -30,8 +34,7 @@
     "ecmaFeatures": {
       "jsx": true
     },
-    "useJSXTextNode": true,
-    "project": "./tsconfig.json"
+    "useJSXTextNode": true
   }
 <%}-%>
 }

--- a/wxplugin/.eslintrc.js
+++ b/wxplugin/.eslintrc.js
@@ -1,4 +1,8 @@
-{
+<%if (framework === 'vue') {-%>
+// ESLint 检查 .vue 文件需要单独配置编辑器：
+// https://eslint.vuejs.org/user-guide/#editor-integrations
+<%}-%>
+module.exports = {
 <%if (!locals.typescript) {-%>
   "extends": ["taro"],
   "rules": {
@@ -30,8 +34,7 @@
     "ecmaFeatures": {
       "jsx": true
     },
-    "useJSXTextNode": true,
-    "project": "./tsconfig.json"
+    "useJSXTextNode": true
   }
 <%}-%>
 }


### PR DESCRIPTION
wxcloud eslint 使用的是 js 格式, 缺少 `module.exports`

wxplugin 统一成 `.eslintrc.js`

删除 `parserOptions.project`, 实际项目经验, 这条配置会让 typescript-eslint 启动 ts 进程分析类型信息, 内存起步 2G, 在没有使用 requiring type checking rules 时, 这条配置是没有必要的, 消除后内存能降到 100M 以下, 速度能会成倍增加.
https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#recommended-configs