### PR TITLE
Add libVersion

### DIFF
--- a/wxcloud/project.config.json
+++ b/wxcloud/project.config.json
@@ -3,6 +3,7 @@
   "cloudfunctionRoot": "cloud/functions/",
   "projectname": "<%= projectName %>",
   "description": "<%= description %>",
+  "libVersion": "<%= libVersion %>",
   "appid": "touristappid",
   "setting": {
     "urlCheck": true,


### PR DESCRIPTION
缺失基础库版本将影响微信开发工具的本地调试功能