### PR TITLE
fix: wxcloud模板在 ts 下跑不起来

### DIFF
--- a/wxcloud/client/src/pages/index/index.jsx
+++ b/wxcloud/client/src/pages/index/index.jsx
@@ -6,7 +6,7 @@ import Taro, { Component } from '@tarojs/taro'
 import { View, Text } from '@tarojs/components'
 import './<%= pageName %>.<%= cssExt %>'
 
-import Login from '../../components/login/index'
+import Login from '../../components/login/index.weapp'
 
 export default class <%= _.capitalize(pageName) %> extends Component {
 

--- a/wxcloud/template_creator.js
+++ b/wxcloud/template_creator.js
@@ -14,6 +14,7 @@ const handler = {
   "/client/config/dev.js": notToChangeExt,
   "/client/config/index.js": notToChangeExt,
   "/client/config/prod.js": notToChangeExt,
+  "/cloud/function/index.js": notToChangeExt,
   "/client/src/pages/index/index.jsx"({ pageName }) {
     return { setPageName: `/client/src/pages/${pageName}/${pageName}.jsx` };
   },


### PR DESCRIPTION
`@taro/helper` 包中模板地址，默认指向的是 v3.1 版本
![image](https://user-images.githubusercontent.com/22864183/142011427-b72f997a-12d3-4e2d-9145-2dc832bcd9dd.png)

而 v3.1 版本下的 wxcloud 模板有如下问题
![image](https://user-images.githubusercontent.com/22864183/142011701-efec448b-8378-4f8b-9be1-20285a27bb8f.png)

js 环境下没试过，ts 下项目跑不起来，需要修改 `ts` 扩展名为 `tsx` 才能跑起来。

我看了一下 master 分支代码是正确的，大佬抽空发个版，同时改一下 `@taro/helper` 地址