### PR TITLE
feat: add bundle release action

### DIFF
--- a/react-native/.github/workflows/taro_playground_bundle_release.yml
+++ b/react-native/.github/workflows/taro_playground_bundle_release.yml
@@ -1,0 +1,48 @@
+# action for bundle taro react native project
+# remove this file if you don't need it
+# see https://github.com/zhiqingchen/taro-react-native-release for details.
+
+on:
+  push:
+    tags: [ v* ]
+  workflow_dispatch:
+
+jobs:
+  taro_release_job:
+    runs-on: ubuntu-latest
+    name: Taro Bundle Release
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v2
+      - name: Cache node_modules Folder
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/node_modules
+          key: ${{ runner.os }}-node_modules
+          restore-keys: ${{ runner.os }}-node_modules
+      - name: Get Yarn Cache Directory Path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache Yarn
+        uses: actions/cache@v2
+        env:
+          cache-name: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install Dependencies
+        run: |
+          yarn
+      - name: Release Taro React Native bundle
+        uses: zhiqingchen/taro-react-native-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Qr Image
+        uses: actions/upload-artifact@v2
+        with:
+          name: bundle-qr-code
+          path: |
+            release/qrcode/ios.png
+            release/qrcode/android.png

--- a/react-native/_gitignore
+++ b/react-native/_gitignore
@@ -65,3 +65,6 @@ buck-out/
 /ios/Pods/
 
 /android/app/src/main/java/com/tarodemo/generated
+
+## taro-react-native-release
+!release/** 


### PR DESCRIPTION
add default action to package your Taro React Native project and generate bundles for Android and iOS. Others can use Taro Playground APP to load the bundle for project preview.

Make it easier to share your ideas.