### PR TITLE
feat: taro3.5版本下将react版本升级至v18

### DIFF
--- a/default-youshu/package.json.tmpl
+++ b/default-youshu/package.json.tmpl
@@ -43,8 +43,8 @@
     "@tarojs/taro-h5": "<%= version %>",<% if (['react', 'preact', 'nerv'].includes(framework)) {%>
     "@tarojs/plugin-framework-react": "<%= version %>",<%}%><% if (framework === 'react') {%>
     "@tarojs/react": "<%= version %>",
-    "react-dom": "^17.0.0",
-    "react": "^17.0.0"<%}%><% if (framework === 'preact') {%>
+    "react-dom": "^18.0.0",
+    "react": "^18.0.0"<%}%><% if (framework === 'preact') {%>
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>
     "nervjs": "^1.5.0"<%}%><% if (framework === 'vue') {%>
     "@tarojs/plugin-framework-vue2": "<%= version %>",
@@ -58,7 +58,7 @@
     "@babel/core": "^7.8.0",
     "@tarojs/cli": "<%= version %>",
     "@types/webpack-env": "^1.13.6",<% if (['react', 'preact', 'nerv'].includes(framework)) {%>
-    "@types/react": "^17.0.2",<%}%><% if (compiler === 'webpack4') {%>
+    "@types/react": "^18.0.0",<%}%><% if (compiler === 'webpack4') {%>
     "@tarojs/mini-runner": "<%= version %>",
     "@tarojs/webpack-runner": "<%= version %>",
     "webpack": "4.46.0",<%} else if (compiler === 'webpack5') {%>

--- a/h5-youshu/package.json.tmpl
+++ b/h5-youshu/package.json.tmpl
@@ -45,8 +45,8 @@
     "@tarojs/taro-h5": "<%= version %>",<% if (['react', 'preact', 'nerv'].includes(framework)) {%>
     "@tarojs/plugin-framework-react": "<%= version %>",<%}%><% if (['react', 'preact', 'nerv'].includes(framework)) {%>
     "@tarojs/react": "<%= version %>",
-    "react-dom": "^16.10.0",
-    "react": "^16.10.0"<%}%><% if (framework === 'preact') {%>
+    "react-dom": "^18.0.0",
+    "react": "^18.0.0"<%}%><% if (framework === 'preact') {%>
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>
     "nervjs": "^1.5.0"<%}%><% if (framework === 'vue') {%>
     "@tarojs/plugin-framework-vue2": "<%= version %>",
@@ -60,7 +60,7 @@
     "@babel/core": "^7.8.0",
     "@tarojs/cli": "<%= version %>",
     "@types/webpack-env": "^1.13.6",<% if (['react', 'preact', 'nerv'].includes(framework)) {%>
-    "@types/react": "^16.0.0",<%}%><% if (compiler === 'webpack4') {%>
+    "@types/react": "^18.0.0",<%}%><% if (compiler === 'webpack4') {%>
     "@tarojs/mini-runner": "<%= version %>",
     "@tarojs/webpack-runner": "<%= version %>",
     "webpack": "4.46.0",<%} else if (compiler === 'webpack5') {%>

--- a/harmony/package.json.tmpl
+++ b/harmony/package.json.tmpl
@@ -56,9 +56,9 @@
     "redux-thunk": "^2.3.0",<% if (framework === 'react') {%>
     "redux": "^4.0.0",
     "react-redux": "^7.2.0",
-    "react-dom": "^17.0.0",
+    "react-dom": "^18.0.0",
     "@tarojs/react": "<%= version %>",
-    "react": "^17.0.0"<%}%><% if (framework === 'preact') {%>
+    "react": "^18.0.0"<%}%><% if (framework === 'preact') {%>
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>
     "nerv-redux": "^1.5.7",
     "nervjs": "^1.5.0"<%}%>
@@ -67,7 +67,7 @@
     "@babel/core": "^7.8.0",
     "@tarojs/cli": "<%= version %>",
     "@types/webpack-env": "^1.13.6",
-    "@types/react": "^17.0.2",<% if (compiler === 'webpack4') {%>
+    "@types/react": "^18.0.0",<% if (compiler === 'webpack4') {%>
     "@tarojs/mini-runner": "<%= version %>",
     "@tarojs/webpack-runner": "<%= version %>",
     "webpack": "4.46.0",<%} else if (compiler === 'webpack5') {%>

--- a/mobx/package.json.tmpl
+++ b/mobx/package.json.tmpl
@@ -51,9 +51,9 @@
     "@tarojs/plugin-framework-react": "<%= version %>",
     "mobx": "^4.8.0",
     "mobx-react": "^6.1.4",<% if (framework === 'react') {%>
-    "react-dom": "^17.0.0",
+    "react-dom": "^18.0.0",
     "@tarojs/react": "<%= version %>",
-    "react": "^17.0.0"<%}%><% if (framework === 'preact') {%>
+    "react": "^18.0.0"<%}%><% if (framework === 'preact') {%>
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>
     "nervjs": "^1.5.0"<%}%>
   },
@@ -61,7 +61,7 @@
     "@babel/core": "^7.8.0",
     "@tarojs/cli": "<%= version %>",
     "@types/webpack-env": "^1.13.6",
-    "@types/react": "^17.0.2",<% if (compiler === 'webpack4') {%>
+    "@types/react": "^18.0.0",<% if (compiler === 'webpack4') {%>
     "@tarojs/mini-runner": "<%= version %>",
     "@tarojs/webpack-runner": "<%= version %>",
     "webpack": "4.46.0",<%} else if (compiler === 'webpack5') {%>

--- a/pwa/package.json.tmpl
+++ b/pwa/package.json.tmpl
@@ -51,8 +51,8 @@
     "@tarojs/taro-h5": "<%= version %>",<% if (['react', 'preact', 'nerv'].includes(framework)) {%>
     "@tarojs/plugin-framework-react": "<%= version %>",<%}%><% if (framework === 'react') {%>
     "@tarojs/react": "<%= version %>",
-    "react-dom": "^17.0.0",
-    "react": "^17.0.0"<%}%><% if (framework === 'preact') {%>
+    "react-dom": "^18.0.0",
+    "react": "^18.0.0"<%}%><% if (framework === 'preact') {%>
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>
     "nervjs": "^1.5.0"<%}%><% if (framework === 'vue') {%>
     "@tarojs/plugin-framework-vue2": "<%= version %>",
@@ -65,7 +65,7 @@
     "@babel/core": "^7.8.0",
     "@tarojs/cli": "<%= version %>",
     "@types/webpack-env": "^1.13.6",<% if (['react', 'preact', 'nerv'].includes(framework)) {%>
-    "@types/react": "^17.0.2",<%}%><% if (compiler === 'webpack4') {%>
+    "@types/react": "^18.0.0",<%}%><% if (compiler === 'webpack4') {%>
     "@tarojs/mini-runner": "<%= version %>",
     "@tarojs/webpack-runner": "<%= version %>",
     "webpack": "4.46.0",<%} else if (compiler === 'webpack5') {%>

--- a/redux/package.json.tmpl
+++ b/redux/package.json.tmpl
@@ -55,9 +55,9 @@
     "redux-thunk": "^2.3.0",
     "redux": "^4.0.0",
     "react-redux": "^7.2.0",<% if (framework === 'react') {%>
-    "react-dom": "^17.0.0",
+    "react-dom": "^18.0.0",
     "@tarojs/react": "<%= version %>",
-    "react": "^17.0.0"<%}%><% if (framework === 'preact') {%>
+    "react": "^18.0.0"<%}%><% if (framework === 'preact') {%>
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>
     "nerv-redux": "^1.5.7",
     "nervjs": "^1.5.0"<%}%>
@@ -66,7 +66,7 @@
     "@babel/core": "^7.8.0",
     "@tarojs/cli": "<%= version %>",
     "@types/webpack-env": "^1.13.6",
-    "@types/react": "^17.0.2",<% if (compiler === 'webpack4') {%>
+    "@types/react": "^18.0.0",<% if (compiler === 'webpack4') {%>
     "@tarojs/mini-runner": "<%= version %>",
     "@tarojs/webpack-runner": "<%= version %>",
     "webpack": "4.46.0",<%} else if (compiler === 'webpack5') {%>

--- a/taro-hooks/package.json.tmpl
+++ b/taro-hooks/package.json.tmpl
@@ -51,8 +51,8 @@
     "@tarojs/taro-h5": "<%= version %>",
     "@tarojs/react": "<%= version %>",
     "@tarojs/plugin-framework-react": "<%= version %>",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "taro-hooks": "latest"
   },
   "devDependencies": {
@@ -76,7 +76,7 @@
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "typescript": "^4.2.3",<%}%>
-    "@types/react": "^17.0.2",
+    "@types/react": "^18.0.0",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-react-hooks": "^4.2.0"

--- a/taro-ui/package.json.tmpl
+++ b/taro-ui/package.json.tmpl
@@ -53,8 +53,8 @@
     "lodash": "4.17.15",
     "taro-ui": "^3.1.0-beta.2",<% if (framework === 'react') {%>
     "@tarojs/react": "<%= version %>",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"<%}%><% if (framework === 'preact') {%>
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"<%}%><% if (framework === 'preact') {%>
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>
     "nervjs": "^1.5.0"<%}%>
   },
@@ -78,7 +78,7 @@
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "typescript": "^4.1.0",<%}%>
-    "@types/react": "^17.0.2",
+    "@types/react": "^18.0.0",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-react-hooks": "^4.2.0"

--- a/wxcloud/client/package.json.tmpl
+++ b/wxcloud/client/package.json.tmpl
@@ -48,8 +48,8 @@
     "lodash": "4.17.15"<% if (['react', 'preact', 'nerv'].includes(framework)) {%>,
     "@tarojs/plugin-framework-react": "<%= version %>"<%}%><% if (['react', 'preact', 'nerv'].includes(framework)) {%>,
     "@tarojs/react": "<%= version %>",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"<%}%><% if (framework === 'preact') {%>,
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"<%}%><% if (framework === 'preact') {%>,
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>,
     "nervjs": "^1.5.0"<%}%><% if (framework === 'vue') {%>,
     "@tarojs/plugin-framework-vue2": "<%= version %>",
@@ -80,7 +80,7 @@
     "react-refresh": "0.11.0",<%}%><% if (framework === 'preact') {%>
     "@prefresh/webpack": "^3.2.3",
     "@prefresh/babel-plugin": "^0.4.1",<%}%><% if (['react', 'preact', 'nerv'].includes(framework)) {%>
-    "@types/react": "^17.0.2",
+    "@types/react": "^18.0.0",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-react-hooks": "^4.2.0",<%}%><% if (typescript) {%>

--- a/wxplugin/package.json.tmpl
+++ b/wxplugin/package.json.tmpl
@@ -51,8 +51,8 @@
     "@tarojs/taro-h5": "<%= version %>",<% if (['react', 'preact', 'nerv'].includes(framework)) {%>
     "@tarojs/plugin-framework-react": "<%= version %>",<%}%><% if (['react', 'preact', 'nerv'].includes(framework)) {%>
     "@tarojs/react": "<%= version %>",
-    "react-dom": "^17.0.0",
-    "react": "^17.0.0"<%}%><% if (framework === 'preact') {%>
+    "react-dom": "^18.0.0",
+    "react": "^18.0.0"<%}%><% if (framework === 'preact') {%>
     "preact": "^10.5.15"<%}%><% if (framework === 'nerv') {%>
     "nervjs": "^1.5.0"<%}%><% if (framework === 'vue') {%>
     "@tarojs/plugin-framework-vue2": "<%= version %>",
@@ -65,7 +65,7 @@
     "@babel/core": "^7.8.0",
     "@tarojs/cli": "<%= version %>",
     "@types/webpack-env": "^1.13.6",<% if (['react', 'preact', 'nerv'].includes(framework)) {%>
-    "@types/react": "^17.0.2",<%}%><% if (compiler === 'webpack4') {%>
+    "@types/react": "^18.0.0",<%}%><% if (compiler === 'webpack4') {%>
     "@tarojs/mini-runner": "<%= version %>",
     "@tarojs/webpack-runner": "<%= version %>",
     "webpack": "4.46.0",<%} else if (compiler === 'webpack5') {%>


### PR DESCRIPTION
Taro 3.5 将模板库内的 react 版本升级为 v18