### PR TITLE
remove taro-plugin-pinia

### DIFF
--- a/vue3-pinia/config/index.js
+++ b/vue3-pinia/config/index.js
@@ -9,7 +9,7 @@ const config = {
   },
   sourceRoot: 'src',
   outputRoot: 'dist',
-  plugins: ['taro-plugin-pinia'],
+  plugins: [],
   defineConstants: {
   },
   copy: {

--- a/vue3-pinia/package.json.tmpl
+++ b/vue3-pinia/package.json.tmpl
@@ -50,8 +50,7 @@
     "@tarojs/taro-h5": "<%= version %>",
     "@tarojs/plugin-framework-vue3": "<%= version %>",
     "vue": "^3.2.24",
-    "pinia": "^2.0.6",
-    "taro-plugin-pinia": "^1.0.0"
+    "pinia": "^2.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",

--- a/vue3-pinia/package.json.tmpl
+++ b/vue3-pinia/package.json.tmpl
@@ -50,7 +50,7 @@
     "@tarojs/taro-h5": "<%= version %>",
     "@tarojs/plugin-framework-vue3": "<%= version %>",
     "vue": "^3.2.24",
-    "pinia": "^2.0.6"
+    "pinia": "^2.0.10"
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",


### PR DESCRIPTION
在 2022-01-27 发布的 pinia: 2.0.10 版本已经修复了此问题

https://github.com/vuejs/pinia/blob/d9629d77f7227943b9b28c689f99814bbb0c9c42/packages/pinia/CHANGELOG.md#2010-2022-01-27