### PR TITLE
fix(postcss-loader): 修复 postcss-loader 包含的 peerDevpendents 没有安装的问题

### DIFF
--- a/default-youshu/package.json.tmpl
+++ b/default-youshu/package.json.tmpl
@@ -86,6 +86,8 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^4.1.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/h5-youshu/package.json.tmpl
+++ b/h5-youshu/package.json.tmpl
@@ -88,6 +88,8 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^3.7.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/harmony/package.json.tmpl
+++ b/harmony/package.json.tmpl
@@ -85,6 +85,8 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^4.1.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/pwa/package.json.tmpl
+++ b/pwa/package.json.tmpl
@@ -94,6 +94,8 @@
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "typescript": "^4.1.0"<%}%>,
-    "workbox-webpack-plugin": "^6.5.4"
+    "workbox-webpack-plugin": "^6.5.4",
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/react-NutUI/package.json.tmpl
+++ b/react-NutUI/package.json.tmpl
@@ -85,6 +85,8 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "stylelint": "^14.4.0",
     "style-loader": "1.3.0",<% if (typescript) {%>
-    "typescript": "^3.7.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/react-native/package.json.tmpl
+++ b/react-native/package.json.tmpl
@@ -91,6 +91,8 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^4.1.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/redux/package.json.tmpl
+++ b/redux/package.json.tmpl
@@ -84,7 +84,9 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^4.1.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   },
   "resolutions": {
     "@types/react": "^17.0.2"

--- a/taro-hooks/package.json.tmpl
+++ b/taro-hooks/package.json.tmpl
@@ -80,7 +80,9 @@
     "@types/react": "^18.0.0",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-react-hooks": "^4.2.0"
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/taro-hooks@canary/package.json.tmpl
+++ b/taro-hooks@canary/package.json.tmpl
@@ -98,7 +98,9 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^4.1.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/taro-ui-vue/package.json.tmpl
+++ b/taro-ui-vue/package.json.tmpl
@@ -79,6 +79,8 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^3.7.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/taro-ui/package.json.tmpl
+++ b/taro-ui/package.json.tmpl
@@ -81,6 +81,8 @@
     "@types/react": "^18.0.0",
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-react-hooks": "^4.2.0"
+    "eslint-plugin-react-hooks": "^4.2.0",
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/vue3-NutUI4/package.json.tmpl
+++ b/vue3-NutUI4/package.json.tmpl
@@ -75,7 +75,9 @@
     "vue-loader": "^17.0.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^3.7.0"<%}%>,
-    "unplugin-vue-components": "^0.23.0"
+    "typescript": "^4.1.0"<%}%>,
+    "unplugin-vue-components": "^0.23.0",
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/vue3-pinia/package.json.tmpl
+++ b/vue3-pinia/package.json.tmpl
@@ -73,6 +73,8 @@
     "vue-loader": "^17.0.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^4.1.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/vuex/package.json.tmpl
+++ b/vuex/package.json.tmpl
@@ -73,6 +73,8 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^3.7.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/wxcloud/client/package.json.tmpl
+++ b/wxcloud/client/package.json.tmpl
@@ -85,9 +85,11 @@
     "eslint-plugin-react-hooks": "^4.2.0",<%}%><% if (typescript) {%>
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^3.7.0",<%}%>
+    "typescript": "^4.1.0",<%}%>
     "eslint-config-taro": "<%= version %>",
     "stylelint": "9.3.0",
-    "postcss": "^8.4.18"
+    "postcss": "^8.4.18",
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }

--- a/wxplugin/package.json.tmpl
+++ b/wxplugin/package.json.tmpl
@@ -92,6 +92,8 @@
     "stylelint": "9.3.0"<% if (typescript) {%>,
     "@typescript-eslint/parser": "^5.20.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
-    "typescript": "^4.1.0"<%}%>
+    "typescript": "^4.1.0"<%}%>,
+    "ts-node": "^10.9.1",
+    "@types/node": "^18.15.11"
   }
 }


### PR DESCRIPTION
- fix
  - 修复 postcss-loader 包含的 peerDevpendents 没有安装的问题