### PR TITLE
fix(nutui-vue3): 补全缺少的逗号

### DIFF
--- a/vue3-NutUI/package.json.tmpl
+++ b/vue3-NutUI/package.json.tmpl
@@ -69,7 +69,7 @@
     "@vitejs/plugin-vue-jsx": "^3.0.0",
     "eslint-plugin-vue": "^8.0.0",{{#if (eq css "Sass") }}
     "sass": "^1.60.0",{{/if}}{{#if (eq css "Less") }}
-    "less": "^4.1.3"{{/if}}{{#if (eq css "Stylus") }}
+    "less": "^4.1.3",{{/if}}{{#if (eq css "Stylus") }}
     "stylus": "^0.59.0",{{/if}}{{#if typescript }}
     "@typescript-eslint/parser": "^6.2.0",
     "@typescript-eslint/eslint-plugin": "^6.2.0",


### PR DESCRIPTION
生成的 json 文件缺少一个逗号