### PR TITLE
fix(wxplugin): Update package.json.tmpl taro init 初始化选择 wxplugin 会生成错误

### DIFF
--- a/wxplugin/package.json.tmpl
+++ b/wxplugin/package.json.tmpl
@@ -91,7 +91,7 @@
     "eslint-plugin-react": "^7.8.2",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-react-hooks": "^4.2.0",{{/if}}
-    "stylelint": "9.3.0",{{/if}}{{#if typescript }}
+    "stylelint": "9.3.0",{{#if typescript }}
     "@typescript-eslint/parser": "^6.2.0",
     "@typescript-eslint/eslint-plugin": "^6.2.0",{{/if}}
     "typescript": "^5.1.0",


### PR DESCRIPTION
相关 bug
[taro init 命令没有可供选择的生成微信小程序插件模版的选项，请官方回复并更新文档](https://github.com/NervJS/taro/issues/17276)

更新 wxplugin 模板，taro init 初始化选择 wxplugin 会生成错误。

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/0350f7a0-52c0-48dd-b25e-9d311b45527d" />